### PR TITLE
Factor out  irasa funs and provide a consistent interface

### DIFF
--- a/pyrasa/irasa.py
+++ b/pyrasa/irasa.py
@@ -167,7 +167,7 @@ def irasa(
             nfft=psd_kwargs.get('nfft'),
         )[1]
 
-    psd, freq = _compute_psd_welch(
+    freq, psd = _compute_psd_welch(
         data,
         fs=fs,
         nperseg=psd_kwargs.get('nperseg'),

--- a/pyrasa/utils/input_classes.py
+++ b/pyrasa/utils/input_classes.py
@@ -1,18 +1,5 @@
 from typing import TypedDict
 
-import numpy as np
-
-
-class IrasaKwargsTyped(TypedDict):
-    nperseg: int | None
-    noverlap: int | None
-    nfft: int | None
-    h: int | None
-    time_orig: None | np.ndarray
-    up_down: str | None
-    dpss_settings: dict
-    win_kwargs: dict
-
 
 class IrasaSprintKwargsTyped(TypedDict):
     mfft: int

--- a/pyrasa/utils/input_classes.py
+++ b/pyrasa/utils/input_classes.py
@@ -18,10 +18,7 @@ class IrasaSprintKwargsTyped(TypedDict):
     mfft: int
     hop: int
     win_duration: float
-    h: int | None
-    up_down: str | None
     dpss_settings: dict
     win_kwargs: dict
-    time_orig: None | np.ndarray
     # smooth: bool
     # n_avgs: list

--- a/pyrasa/utils/irasa_utils.py
+++ b/pyrasa/utils/irasa_utils.py
@@ -137,7 +137,6 @@ def _compute_psd_welch(
     scaling: str = 'density',
     axis: int = -1,
     average: str = 'mean',
-    spectrum_only: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Function to compute power spectral densities using welchs method"""
 
@@ -168,10 +167,7 @@ def _compute_psd_welch(
         weighted_psds = [ratios[ix] * cur_sgramm for ix, cur_sgramm in enumerate(psds)]
         psd = np.sum(weighted_psds, axis=0) / np.sum(ratios)
 
-    if spectrum_only:
-        return psd
-    else:
-        return freq, psd
+    return freq, psd
 
 
 def _compute_sgramm(  # noqa C901
@@ -185,8 +181,7 @@ def _compute_sgramm(  # noqa C901
     up_down: str | None = None,
     h: int | None = None,
     time_orig: np.ndarray | None = None,
-    spectrum_only: bool = False,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray] | np.ndarray:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Function to compute spectrograms"""
 
     if h is None:
@@ -228,7 +223,4 @@ def _compute_sgramm(  # noqa C901
 
     sgramm = np.squeeze(sgramm)  # bring in proper format
 
-    if spectrum_only:
-        return sgramm
-    else:
-        return freq, time, sgramm
+    return freq, time, sgramm

--- a/pyrasa/utils/irasa_utils.py
+++ b/pyrasa/utils/irasa_utils.py
@@ -137,10 +137,7 @@ def _compute_psd_welch(
     scaling: str = 'density',
     axis: int = -1,
     average: str = 'mean',
-    up_down: str | None = None,
     spectrum_only: bool = False,
-    h: float | None = None,
-    time_orig: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Function to compute power spectral densities using welchs method"""
 

--- a/pyrasa/utils/types.py
+++ b/pyrasa/utils/types.py
@@ -5,5 +5,5 @@ import numpy as np
 
 class IrasaFun(Protocol):
     def __call__(
-        self, data: np.ndarray, fs: int, h: float | None, up_down: str | None, time_orig: np.ndarray | None = None
-    ) -> tuple[np.ndarray, np.ndarray]: ...
+        self, data: np.ndarray, fs: int, h: int | None, up_down: str | None, time_orig: np.ndarray | None = None
+    ) -> np.ndarray: ...

--- a/pyrasa/utils/types.py
+++ b/pyrasa/utils/types.py
@@ -1,0 +1,9 @@
+from typing import Protocol
+
+import numpy as np
+
+
+class IrasaFun(Protocol):
+    def __call__(
+        self, data: np.ndarray, fs: int, h: float | None, up_down: str | None, time_orig: np.ndarray | None = None
+    ) -> tuple[np.ndarray, np.ndarray]: ...


### PR DESCRIPTION
This PR leaves the `_compute_psd_welch` and `_compute_sgramm` functions in their `irasa_utils.py` file but at the same time introduces a consistent and convenient interface for functions that `_gen_irasa` can use.

The idea is basically that `_gen_irasa` request a function with a specific set of parameters (which is specified in `utils/types.py` so mypy catches it). The signature of this function is constraint to be:

```python
def fun(data: np.ndarray, fs: int, h: int | None, up_down: str | None, time_orig: np.ndarray | None = None
    ) -> np.ndarray
```

The actutal irasa functions (like `irasa` or `irasa_sprint`) the generate a lightweight local function following this exact signature and call the respective function that is imported from `irasa_utils.py`. So, the local function consists only of the definition and the immediatly returned call to the low-level function like this example in `irasa`:

```python
    def _local_irasa_fun(
        data: np.ndarray,
        fs: int,
        *args: Any,
        **kwargs: Any,
    ) -> np.ndarray:
        return _compute_psd_welch(
            data,
            fs=fs,
            nperseg=psd_kwargs.get('nperseg'),
            win_kwargs=win_kwargs,
            dpss_settings=dpss_settings,
            noverlap=psd_kwargs.get('noverlap'),
            nfft=psd_kwargs.get('nfft'),
        )[1]

    freq, psd = _compute_psd_welch(
        data,
        fs=fs,
        nperseg=psd_kwargs.get('nperseg'),
        win_kwargs=win_kwargs,
        dpss_settings=dpss_settings,
        noverlap=psd_kwargs.get('noverlap'),
        nfft=psd_kwargs.get('nfft'),
    )

    psd, psd_aperiodic, psd_periodic = _gen_irasa(
        data=np.squeeze(data), orig_spectrum=psd, fs=fs, irasa_fun=_local_irasa_fun, hset=hset
    )
```

As you see, the responsibility to handle the kwargs for the low-level functions is now on the local functions and not anymore on the `_gen_irasa` because it does not really need to care about these....

This is going to make any efforts of porting it to cython much easier btw.

closes #35 