### PR TITLE
scale_factor calculation was changed.

### DIFF
--- a/pyrasa/utils/aperiodic_utils.py
+++ b/pyrasa/utils/aperiodic_utils.py
@@ -133,7 +133,7 @@ def compute_aperiodic_model(
         def num_zeros(decimal: int) -> float:
             return np.inf if decimal == 0 else -np.floor(np.log10(abs(decimal))) - 1
 
-        scale_factor = 10 ** num_zeros(aperiodic_spectrum.min())
+        scale_factor = 10 ** (num_zeros(aperiodic_spectrum.min())-3)
         aperiodic_spectrum = aperiodic_spectrum * scale_factor
     else:
         scale_factor = 1


### PR DESCRIPTION
Hey,

I'm working with PyRASA on a large rs-MEG dataset (~1,500 recordings) across multiple scanners. When fitting aperiodic components in knee mode with `scale=True`, roughly 100 recordings threw the following error:

`ValueError: array must not contain infs or NaNs`

originating from:

`p, _ = curve_fit(self.func, self.freq, self.aperiodic_spectrum, **curve_kwargs)`

Lowering the scale factor resolved the issue, so I'm submitting this PR as a fix. That said, I'm not confident this approach will generalize to EEG datasets, which typically have a higher amplitude range. I'd be happy to collaborate on exploring alternative solutions that work reliably for both MEG and EEG.